### PR TITLE
Keep the environments columnised on small screens

### DIFF
--- a/blinken.js
+++ b/blinken.js
@@ -76,7 +76,7 @@
         var environment_style_class = self.getEnvironmentStyleClass(environment.critical_entries, environment.warning_entries);
         var critical_entries = self.getEntryHTML("critical", "Criticals", environment.critical_entries);
         var warning_entries = self.getEntryHTML("warning", "Warnings", environment.warning_entries);
-        var environment_block = '<a href="' + environment.environment_url + '" target="_blank" class="col-md-3 blinken-environment ' + environment_style_class + '"><h2>' + environment.environment_name + '</h2><p>' + environment.timestamp + '</p>' + critical_entries + warning_entries + '</a>';
+        var environment_block = '<a href="' + environment.environment_url + '" target="_blank" class="col-xs-4 blinken-environment ' + environment_style_class + '"><h2>' + environment.environment_name + '</h2><p>' + environment.timestamp + '</p>' + critical_entries + warning_entries + '</a>';
         self.$container.children("#" + group_id).append(environment_block);
       }
     });

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+body {
+  min-width: 600px;
+}
+
 .container-fluid {
   margin: 20px;
 }


### PR DESCRIPTION
Currently we display the environments vertically when the screen is small. This makes sure that even on small screens like the 2nd line monitor the environments display horizontally.

## Before

![screen shot 2017-11-02 at 11 43 33](https://user-images.githubusercontent.com/233676/32324380-1ca520b6-bfc3-11e7-926d-288a30a849b6.png)
<img width="1550" alt="screen shot 2017-11-02 at 11 43 36" src="https://user-images.githubusercontent.com/233676/32324381-1cc13cb0-bfc3-11e7-8e09-373b8a2c755b.png">


## After

![screen shot 2017-11-02 at 11 43 20](https://user-images.githubusercontent.com/233676/32324378-1c60f81e-bfc3-11e7-98e0-a41a6d642cb2.png)
![screen shot 2017-11-02 at 11 43 24](https://user-images.githubusercontent.com/233676/32324379-1c7fd248-bfc3-11e7-912a-e373a047adec.png)
