### PR TITLE
Exclude alerts marked as scheduled downtime from count

### DIFF
--- a/app/blinken.js
+++ b/app/blinken.js
@@ -46,8 +46,12 @@
     var self = this;
     $.getJSON(environment_url + "/cgi-bin/icinga/status.cgi?servicestatustypes=20&jsonoutput=1", function(data) {
       var service_status = data.status.service_status;
-      var critical_entries = service_status.filter(function(o) { return o.status === "CRITICAL" && o.has_been_acknowledged === false }).length;
-      var warning_entries = service_status.filter(function(o) { return o.status === "WARNING" && o.has_been_acknowledged === false }).length;
+      var critical_entries = service_status.filter(function(o) { return o.status === "CRITICAL" &&
+                                                                        o.has_been_acknowledged === false &&
+                                                                        o.in_scheduled_downtime === false }).length;
+      var warning_entries = service_status.filter(function(o) { return o.status === "WARNING" &&
+                                                                       o.has_been_acknowledged === false &&
+                                                                       o.in_scheduled_downtime === false }).length;
       self.setStatus(group_id, environment_name, environment_url, critical_entries, warning_entries);
     });
   };

--- a/app/blinken.js
+++ b/app/blinken.js
@@ -45,13 +45,11 @@
   Blinken.prototype.getStatus = function(group_id, environment_name, environment_url) {
     var self = this;
     $.getJSON(environment_url + "/cgi-bin/icinga/status.cgi?servicestatustypes=20&jsonoutput=1", function(data) {
-      var service_status = data.status.service_status;
-      var critical_entries = service_status.filter(function(o) { return o.status === "CRITICAL" &&
-                                                                        o.has_been_acknowledged === false &&
-                                                                        o.in_scheduled_downtime === false }).length;
-      var warning_entries = service_status.filter(function(o) { return o.status === "WARNING" &&
-                                                                       o.has_been_acknowledged === false &&
-                                                                       o.in_scheduled_downtime === false }).length;
+      var service_status = data.status.service_status.filter(function(o) {
+        return o.has_been_acknowledged === false && o.in_scheduled_downtime === false;
+      });
+      var critical_entries = service_status.filter(function(o) { return o.status === "CRITICAL" }).length;
+      var warning_entries = service_status.filter(function(o) { return o.status === "WARNING" }).length;
       self.setStatus(group_id, environment_name, environment_url, critical_entries, warning_entries);
     });
   };

--- a/app/blinken.js
+++ b/app/blinken.js
@@ -45,11 +45,15 @@
   Blinken.prototype.getStatus = function(group_id, environment_name, environment_url) {
     var self = this;
     $.getJSON(environment_url + "/cgi-bin/icinga/status.cgi?servicestatustypes=20&jsonoutput=1", function(data) {
-      var service_status = data.status.service_status.filter(function(o) {
-        return o.has_been_acknowledged === false && o.in_scheduled_downtime === false;
+      var active_service_status = data.status.service_status.filter(function(service_status) {
+        return service_status.has_been_acknowledged === false && service_status.in_scheduled_downtime === false;
       });
-      var critical_entries = service_status.filter(function(o) { return o.status === "CRITICAL" }).length;
-      var warning_entries = service_status.filter(function(o) { return o.status === "WARNING" }).length;
+      var critical_entries = active_service_status.filter(function(service_status) {
+        return service_status.status === "CRITICAL";
+      }).length;
+      var warning_entries = active_service_status.filter(function(service_status) {
+        return service_status.status === "WARNING";
+      }).length;
       self.setStatus(group_id, environment_name, environment_url, critical_entries, warning_entries);
     });
   };


### PR DESCRIPTION
Previously this was just ignoring alerts marked as acknowledged.