### PR TITLE
Handle errors from Icinga gracefully

### DIFF
--- a/app/blinken.js
+++ b/app/blinken.js
@@ -44,20 +44,28 @@
 
   Blinken.prototype.getStatus = function(group_id, environment_name, environment_url) {
     var self = this;
-    $.getJSON(environment_url + "/cgi-bin/icinga/status.cgi?servicestatustypes=28&jsonoutput=1", function(data) {
-      var active_service_status = data.status.service_status.filter(function(service_status) {
-        return service_status.has_been_acknowledged === false && service_status.in_scheduled_downtime === false;
-      });
-      var critical_entries = active_service_status.filter(function(service_status) {
-        return service_status.status === "CRITICAL";
-      }).length;
-      var warning_entries = active_service_status.filter(function(service_status) {
-        return service_status.status === "WARNING";
-      }).length;
-      var unknown_entries = active_service_status.filter(function(service_status) {
-        return service_status.status === "UNKNOWN";
-      }).length;
-      self.setStatus(group_id, environment_name, environment_url, critical_entries, warning_entries, unknown_entries);
+    $.ajax({
+      dataType: "json",
+      url: environment_url + "/cgi-bin/icinga/status.cgi?servicestatustypes=28&jsonoutput=1",
+      timeout: 5000,
+      success: function(data) {
+        var active_service_status = data.status.service_status.filter(function(service_status) {
+          return service_status.has_been_acknowledged === false && service_status.in_scheduled_downtime === false;
+        });
+        var critical_entries = active_service_status.filter(function(service_status) {
+          return service_status.status === "CRITICAL";
+        }).length;
+        var warning_entries = active_service_status.filter(function(service_status) {
+          return service_status.status === "WARNING";
+        }).length;
+        var unknown_entries = active_service_status.filter(function(service_status) {
+          return service_status.status === "UNKNOWN";
+        }).length;
+        self.setStatus(group_id, environment_name, environment_url, critical_entries, warning_entries, unknown_entries);
+      },
+      error: function() {
+        self.setStatus(group_id, environment_name, environment_url, "?", "?", "?");
+      }
     });
   };
 


### PR DESCRIPTION
This commit adds error handling when calling Icinga. There is a 5 second timeout and an error handler, both of which will result in the “unavailable” state being shown.