### PR TITLE
Fix non-Chrome compatibility

### DIFF
--- a/app/blinken.js
+++ b/app/blinken.js
@@ -11,10 +11,10 @@
   };
 
   Blinken.prototype.getConfig = function() {
-    var chromeExtensionConfig = chrome &&
-      chrome.extension &&
-      chrome.extension.getBackgroundPage() &&
-      chrome.extension.getBackgroundPage().blinken_config;
+    var chromeExtensionConfig = window.chrome &&
+      window.chrome.extension &&
+      window.chrome.extension.getBackgroundPage() &&
+      window.chrome.extension.getBackgroundPage().blinken_config;
 
     if (chromeExtensionConfig) {
       window.blinken_config = chromeExtensionConfig;


### PR DESCRIPTION
Testing for `chrome` results in an error in Safari:
```
ReferenceError: Can't find variable: chrome
```

Changing this to testing for `window.chrome` means it will actually
be `undefined` in Safari rather than erroring.