### PR TITLE
Add AWS production

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -17,12 +17,16 @@ var blinken_config = {
           "url": "https://alert.integration.publishing.service.gov.uk"
         },
         {
-          "name": "CI",
-          "url": "https://ci-alert.integration.publishing.service.gov.uk"
+          "name": "AWS Staging",
+          "url": "https://alert.blue.staging.govuk.digital"
         },
         {
-          "name": "AWS Staging",
-          "url": "https://alert.staging.govuk.digital"
+          "name": "AWS Production",
+          "url": "https://alert.blue.production.govuk.digital"
+        },
+        {
+          "name": "CI",
+          "url": "https://ci-alert.integration.publishing.service.gov.uk"
         }
       ]
     }


### PR DESCRIPTION
This adds AWS production to the default configuration so it's available on the 2nd line board.

Also moved the CI box below the AWS boxes.