### PR TITLE
Add AWS and CI environments to Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,18 @@ You will need to point the extension at the Icinga alert pages in order to use i
 
 ### Usage
 
-The icon uses the Blinken traffic light system:
+The icon uses the following colour scheme:
 
 - Green means no warnings
+- Purple means some unknown alerts, but no warnings or critical alerts
 - Amber means some warnings, but no critical alerts
 - Red means some critical alerts
 
 The big block across the top of the icon represents Production. The medium-sized one at the bottom-left represents
-Staging, and the small block in the bottom-right represents Integration.
+Staging, and the small block in the bottom-right represents Integration. AWS Staging and Production environments are
+not yet represented in the icon but will be once the majority of applications have been migrated.
 
-Clicking on the icon will open up the Blinken page with more information. Each environment can be clicked to be taken
+Clicking on the icon will open up the BlinkenJS page with more information. Each environment can be clicked to be taken
 to the corresponding Icinga page.  
 
 ### Notifications

--- a/app/blinken.js
+++ b/app/blinken.js
@@ -129,7 +129,7 @@
 
   Blinken.prototype.getEntryHTML = function(entry_type, entry_name, number_of_entries) {
     if (number_of_entries === 0) {
-      return '<div class="blinken-entry"></div>';
+      return '<div class="blinken-entry"><h3>&nbsp;</h3><p>&nbsp;</p></div>';
     } else {
       return '<div class="blinken-entry blinken-' + entry_type + '-entries"><h3>' + number_of_entries + '</h3><p>' + entry_name + '</p></div>';
     }

--- a/app/config.js
+++ b/app/config.js
@@ -17,12 +17,12 @@ var blinken_config = {
           "url": "https://alert.integration.publishing.service.gov.uk"
         },
         {
-          "name": "AWS Staging",
-          "url": "https://alert.blue.staging.govuk.digital"
-        },
-        {
           "name": "AWS Production",
           "url": "https://alert.blue.production.govuk.digital"
+        },
+        {
+          "name": "AWS Staging",
+          "url": "https://alert.blue.staging.govuk.digital"
         },
         {
           "name": "CI",

--- a/app/styles.css
+++ b/app/styles.css
@@ -5,6 +5,7 @@ body {
 
 .container-fluid {
   margin: 20px;
+  min-width: 300px;
 }
 
 .blinken-environment {

--- a/chrome/blinken.js
+++ b/chrome/blinken.js
@@ -49,6 +49,18 @@
             {
               "name": "Integration",
               "url": icingaUrls.integration
+            },
+            {
+              "name": "AWS Production",
+              "url": icingaUrls.production_aws
+            },
+            {
+              "name": "AWS Staging",
+              "url": icingaUrls.staging_aws
+            },
+            {
+              "name": "CI",
+              "url": icingaUrls.ci
             }
           ]
         }

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -21,6 +21,21 @@
   <input id="integration-url" type="text"/>
 </div>
 
+<div>
+  <label for="production-aws-url">AWS Production Icinga URL</label>
+  <input id="production-aws-url" type="text"/>
+</div>
+
+<div>
+  <label for="staging-aws-url">AWS Staging Icinga URL</label>
+  <input id="staging-aws-url" type="text"/>
+</div>
+
+<div>
+  <label for="ci-url">CI Icinga URL</label>
+  <input id="ci-url" type="text"/>
+</div>
+
 <h2>Polling</h2>
 <div>
   <label for="polling-interval">Polling Interval (secs)</label>
@@ -102,6 +117,84 @@
 <div>
   <label for="integration-notification-ok">
     <input type="checkbox" id="integration-notification-ok" />
+    OK
+  </label>
+</div>
+
+<h3>AWS Production</h3>
+<div>
+  <label for="production-aws-notification-critical">
+    <input type="checkbox" id="production-aws-notification-critical" />
+    Critical
+  </label>
+</div>
+<div>
+  <label for="production-aws-notification-warning">
+    <input type="checkbox" id="production-aws-notification-warning" />
+    Warning
+  </label>
+</div>
+<div>
+  <label for="production-aws-notification-unknown">
+    <input type="checkbox" id="production-aws-notification-unknown" />
+    Unknown
+  </label>
+</div>
+<div>
+  <label for="production-aws-notification-ok">
+    <input type="checkbox" id="production-aws-notification-ok" />
+    OK
+  </label>
+</div>
+
+<h3>AWS Staging</h3>
+<div>
+  <label for="staging-aws-notification-critical">
+    <input type="checkbox" id="staging-aws-notification-critical" />
+    Critical
+  </label>
+</div>
+<div>
+  <label for="staging-aws-notification-warning">
+    <input type="checkbox" id="staging-aws-notification-warning" />
+    Warning
+  </label>
+</div>
+<div>
+  <label for="staging-aws-notification-unknown">
+    <input type="checkbox" id="staging-aws-notification-unknown" />
+    Unknown
+  </label>
+</div>
+<div>
+  <label for="staging-aws-notification-ok">
+    <input type="checkbox" id="staging-aws-notification-ok" />
+    OK
+  </label>
+</div>
+
+<h3>CI</h3>
+<div>
+  <label for="ci-notification-critical">
+    <input type="checkbox" id="ci-notification-critical" />
+    Critical
+  </label>
+</div>
+<div>
+  <label for="ci-notification-warning">
+    <input type="checkbox" id="ci-notification-warning" />
+    Warning
+  </label>
+</div>
+<div>
+  <label for="ci-notification-unknown">
+    <input type="checkbox" id="ci-notification-unknown" />
+    Unknown
+  </label>
+</div>
+<div>
+  <label for="ci-notification-ok">
+    <input type="checkbox" id="ci-notification-ok" />
     OK
   </label>
 </div>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -3,12 +3,16 @@
   var ENVIRONMENTS = [
     "production",
     "staging",
-    "integration"
+    "integration",
+    "production-aws",
+    "staging-aws",
+    "ci"
   ];
 
   function saveOptions() {
     var icingaUrls = ENVIRONMENTS.reduce(function (urlsByEnvironment, environment) {
-      urlsByEnvironment[environment] = document.getElementById(environment + "-url").value;
+      environmentName = environment.replace("-", "_");
+      urlsByEnvironment[environmentName] = document.getElementById(environment + "-url").value;
       return urlsByEnvironment;
     }, {});
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GOV.UK Blinken",
   "description": "An extension for monitoring GOV.UK services",
-  "version": "0.1.0",
+  "version": "0.2.0",
 
   "browser_action": {
     "default_icon": "chrome/icons/grey.png",


### PR DESCRIPTION
This PR adds the AWS staging and production and CI environments to the Chrome extension and makes some other small tweaks. See individual commits for more details.