### PR TITLE
Show environments without alerts with smaller boxes

### DIFF
--- a/app/blinken.js
+++ b/app/blinken.js
@@ -129,7 +129,7 @@
 
   Blinken.prototype.getEntryHTML = function(entry_type, entry_name, number_of_entries) {
     if (number_of_entries === 0) {
-      return '<div class="blinken-entry"><h3>&nbsp;</h3><p>&nbsp;</p></div>';
+      return '<div class="blinken-entry hidden-xs"><h3>&nbsp;</h3><p>&nbsp;</p></div>';
     } else {
       return '<div class="blinken-entry blinken-' + entry_type + '-entries"><h3>' + number_of_entries + '</h3><p>' + entry_name + '</p></div>';
     }


### PR DESCRIPTION
Currently, it's hard to see all the entries on small displays. To free
up some space, don't reserve any space for environments without any
alerts.

The hidden-xs class means that when the boxes are displayed
vertically, they will take up less vertical space, but they'll still
be the same size on larger screens, where a grid layout is used.

## Before

![blinkenjs-before](https://user-images.githubusercontent.com/1130010/50693434-d8011380-102e-11e9-939a-a8243f1a510f.png)

## After

![blinkenjs-after](https://user-images.githubusercontent.com/1130010/50693433-d8011380-102e-11e9-87b0-34c5fe135f25.png)