### PR TITLE
Update default config environment names

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -5,19 +5,19 @@ var blinken_config = {
       "name": "",
       "environments": [
         {
-          "name": "Production",
+          "name": "Production (Carrenza)",
           "url": "https://alert.publishing.service.gov.uk"
         },
         {
-          "name": "AWS Production",
+          "name": "Production (AWS)",
           "url": "https://alert.blue.production.govuk.digital"
         },
         {
-          "name": "Staging",
+          "name": "Staging (Carrenza)",
           "url": "https://alert.staging.publishing.service.gov.uk"
         },
         {
-          "name": "AWS Staging",
+          "name": "Staging (AWS)",
           "url": "https://alert.blue.staging.govuk.digital"
         },
         {


### PR DESCRIPTION
It used to be that there were separate environments running in AWS,
but now Production and Staging as environments span both Carrenza and
AWS infrastructure, and there are important things that occur between
them.

Therefore, refer to the Icinga instances by the environment first,
then specify the hosting provider if there's more than one for that
environment.